### PR TITLE
Don't pull newer image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,8 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <dockerfile.verbose>true</dockerfile.verbose>
+                            <pullNewerImage>false</pullNewerImage>
+                            <verbose>false</verbose>
                             <repository>openliberty-${project.artifactId}</repository>
                             <tag>${project.version}</tag>
                             <buildArgs>


### PR DESCRIPTION
Allows build to run without network

If you've built it once, it should have downloaded everything required. Without this property, it will contact docker hub to check for an updated version of the openliberty docker image which will fail if you're not online.